### PR TITLE
Only treat top level fault nodes as a SOAPFault

### DIFF
--- a/lib/savon/soap_fault.rb
+++ b/lib/savon/soap_fault.rb
@@ -3,7 +3,7 @@ module Savon
 
     def self.present?(http, xml = nil)
       xml ||= http.body
-      fault_node  = xml.include?("Fault>")
+      fault_node  = xml =~ /body>\s*<[^>]*fault>/i
       soap1_fault = xml.include?("faultcode>") && xml.include?("faultstring>")
       soap2_fault = xml.include?("Code>") && xml.include?("Reason>")
 

--- a/spec/fixtures/response/nested_soap_fault.xml
+++ b/spec/fixtures/response/nested_soap_fault.xml
@@ -1,0 +1,14 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+   <soap:Body>
+      <topLevelNode>
+         <nestedNode></nestedNode>
+         <nestedNode></nestedNode>
+         <nestedNode>
+            <soap:ServiceFault>
+               <faultcode>soap:Server</faultcode>
+               <faultstring>Fault occurred while processing.</faultstring>
+            </soap:ServiceFault>
+         </nestedNode>
+      </topLevelNode>
+   </soap:Body>
+</soap:Envelope>

--- a/spec/fixtures/response/nested_soap_fault12.xml
+++ b/spec/fixtures/response/nested_soap_fault12.xml
@@ -1,0 +1,24 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:m="http://www.example.org/timeouts">
+  <soap:Body>
+    <topLevelNode>
+      <nestedNode></nestedNode>
+      <nestedNode></nestedNode>
+      <nestedNode>
+        <soap:Fault>
+          <Code>
+            <Value>soap:Sender</Value>
+            <Subcode>
+              <Value>m:MessageTimeout</Value>
+            </Subcode>
+          </Code>
+          <Reason>
+            <Text xml:lang="en">Sender Timeout</Text>
+          </Reason>
+          <Detail>
+            <m:MaxTime>P5M</m:MaxTime>
+          </Detail>
+        </soap:Fault>
+      </nestedNode>
+    </topLevelNode>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/savon/soap_fault_spec.rb
+++ b/spec/savon/soap_fault_spec.rb
@@ -7,6 +7,7 @@ describe Savon::SOAPFault do
   let(:soap_fault_nc) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault)), nori_no_convert }
   let(:soap_fault_nc2) { Savon::SOAPFault.new new_response(:body => Fixture.response(:soap_fault12)), nori_no_convert }
   let(:another_soap_fault) { Savon::SOAPFault.new new_response(:body => Fixture.response(:another_soap_fault)), nori }
+  let(:nested_soap_fault) { Savon::SOAPFault.new new_response(:body => Fixture.response(:nested_soap_fault)), nori }
   let(:soap_fault_no_body) { Savon::SOAPFault.new new_response(:body => {}), nori }
   let(:no_fault) { Savon::SOAPFault.new new_response, nori }
 
@@ -39,8 +40,23 @@ describe Savon::SOAPFault do
       expect(Savon::SOAPFault.present? http).to be_truthy
     end
 
+    it "returns true if the HTTP response contains a funky SOAP fault" do
+      http = new_response(:body => Fixture.response(:soap_fault_funky))
+      expect(Savon::SOAPFault.present? http).to be_truthy
+    end
+
     it "returns false unless the HTTP response contains a SOAP fault" do
       expect(Savon::SOAPFault.present? new_response).to be_falsey
+    end
+
+    it "returns false if the HTTP response contains a nested SOAP 1.1 fault" do
+      http = new_response(:body => Fixture.response(:nested_soap_fault))
+      expect(Savon::SOAPFault.present? http).to be_falsey
+    end
+
+    it "returns false if the HTTP response contains a nested SOAP 1.2 fault" do
+      http = new_response(:body => Fixture.response(:nested_soap_fault12))
+      expect(Savon::SOAPFault.present? http).to be_falsey
     end
   end
 
@@ -68,6 +84,10 @@ describe Savon::SOAPFault do
 
       it "works even if the keys are different in a funky SOAP fault message" do
         expect(soap_fault_funky.send method).to eq("(42) The Answer to Life The Universe And Everything")
+      end
+
+      it "raises NoMethodError when parsing nested fault nodes" do
+        expect{nested_soap_fault.send method}.to raise_error(NoMethodError)
       end
     end
   end


### PR DESCRIPTION
When a response contains a nested fault node (anywhere other than a direct child of `Body`), the `SOAPFault.present?` class method returns true, but Nori is unable to properly find the fault node (`nori.find(to_hash, 'Fault')`). In that scenario, you are left w/ a `NoMethodError: undefined method 'each' for nil:NilClass` (spec added to show this scenario).

Rather than treat this scenario as a `SOAPFault`, it would be preferable to parse the response normally. This will also cover the scenarios of potentially having other node names that end in `Fault>`, `Code>`, `Reason>`, etc.

This should address the following open issues:
https://github.com/savonrb/savon/issues/841
https://github.com/savonrb/savon/issues/769

Note: Using a regex matcher here caused benchmark tests of the `SOAPFault.present?` method to run ~50% slower; running the `.present?` spec 5 million times for another_soap_fault.xml took 20 seconds when using `.include?("Fault>")`, and 30 seconds when using the regex matcher, so we're talking about a difference of a couple microsecond for parsing a relatively small file.